### PR TITLE
Fix build in release

### DIFF
--- a/Sources/WebSocketActors/Continuation.swift
+++ b/Sources/WebSocketActors/Continuation.swift
@@ -30,13 +30,13 @@ import Foundation
     @inlinable func withContinuation<T>(function: String = #function,
                                         _ body: (UnsafeContinuation<T, Never>) -> Void) async -> T
     {
-        await withUnsafeContinuation(function: function, body)
+        await withUnsafeContinuation(body)
     }
 
     @inlinable func withThrowingContinuation<T>(function: String = #function,
                                                 _ body: (UnsafeContinuation<T, Error>) -> Void) async throws -> T
     {
-        try await withUnsafeThrowingContinuation(function: function, body)
+        try await withUnsafeThrowingContinuation(body)
     }
 #endif
 

--- a/Tests/WebSocketActorTests/ActorIdentityTests.swift
+++ b/Tests/WebSocketActorTests/ActorIdentityTests.swift
@@ -5,7 +5,7 @@
 //  Created by Stuart A. Malone on 11/2/23.
 //
 
-@testable import WebSocketActors
+import WebSocketActors
 import XCTest
 
 final class ActorIdentityTests: XCTestCase {

--- a/Tests/WebSocketActorTests/WebSocketActorTests.swift
+++ b/Tests/WebSocketActorTests/WebSocketActorTests.swift
@@ -1,7 +1,7 @@
 import Distributed
 import Logging
 import NIO
-@testable import WebSocketActors
+import WebSocketActors
 import XCTest
 
 typealias DefaultDistributedActorSystem = WebSocketActorSystem


### PR DESCRIPTION
The following fixes are proposed to enable the library to compile in release mode. 

Thanks for creating this library!

This was the build error given when compiling in release prior to these changes:
```
/Users/justinmeans/Downloads/websocket-actor-system/Sources/WebSocketActors/Continuation.swift:33:58: error: extra argument in call
        await withUnsafeContinuation(function: function, body)
                                    ~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/justinmeans/Downloads/websocket-actor-system/Sources/WebSocketActors/Continuation.swift:33:48: error: cannot convert value of type 'String' to expected argument type '(UnsafeContinuation<T, Never>) -> Void'
        await withUnsafeContinuation(function: function, body)
                                               ^
/Users/justinmeans/Downloads/websocket-actor-system/Sources/WebSocketActors/Continuation.swift:39:70: error: extra argument in call
        try await withUnsafeThrowingContinuation(function: function, body)
                                                ~~~~~~~~~~~~~~~~~~~~~^~~~~
/Users/justinmeans/Downloads/websocket-actor-system/Sources/WebSocketActors/Continuation.swift:39:60: error: cannot convert value of type 'String' to expected argument type '(UnsafeContinuation<T, any Error>) -> Void'
        try await withUnsafeThrowingContinuation(function: function, body)
```